### PR TITLE
Allow for setting of policyLocation on Jolokia agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ includes and initializes it (e.g. the SBT plugin for Play Framework 2.4.x).
 Add the following to your `project/plugins.sbt` file:
 
 ```scala
-addSbtPlugin("com.jatescher" % "sbt-jolokia" % "1.1.2")
+addSbtPlugin("com.jatescher" % "sbt-jolokia" % "1.1.3")
 ```
 
 To use the Jolokia settings in your project, add the `Jolokia` auto-plugin to your project.
@@ -45,6 +45,12 @@ To use a specific `jolokia-jvm` version, add the following to your `build.sbt` f
 
 ```scala
 jolokiaVersion := "1.3.7"
+```
+
+To set the location of the access policy file (for example, to `/etc/jolokia/jolokia-access.xml`):
+
+```scala
+jolokiaPolicyLocation :="file:/etc/jolokia/jolokia-access.xml"
 ```
 
 ## Testing

--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,7 @@ lazy val `sbt-jolokia` = (project in file("."))
   .settings(
     name := """sbt-jolokia""",
     organization := "com.jatescher",
-    version := "1.1.2",
+    version := "1.1.3",
     sbtPlugin := true,
     crossSbtVersions := Seq("0.13.17", "1.0.4"),
     addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.3.4" % "provided")

--- a/src/main/scala/com/jatescher/Jolokia.scala
+++ b/src/main/scala/com/jatescher/Jolokia.scala
@@ -16,6 +16,7 @@ object Jolokia extends AutoPlugin {
     val jolokiaPort = settingKey[String]("Jolokia port")
     val jolokiaHost = settingKey[String]("Jolokia host")
     val jolokiaProtocol = settingKey[String]("Jolokia protocol")
+    val jolokiaPolicyLocation = settingKey[String]("Jolokia policy location")
   }
 
   import autoImport._
@@ -31,6 +32,7 @@ object Jolokia extends AutoPlugin {
     jolokiaPort := "8778",
     jolokiaHost := "0.0.0.0",
     jolokiaProtocol := "https",
+    jolokiaPolicyLocation := "classpath:/jolokia-access.xml",
     libraryDependencies += "org.jolokia" % "jolokia-jvm" % jolokiaVersion.value % jolokiaConfig classifier "agent",
     mappings in Universal ++= Seq(
       jolokiaAgent.value -> "jolokia/jolokia.jar"
@@ -38,7 +40,8 @@ object Jolokia extends AutoPlugin {
     bashScriptExtraDefines += s"JOLOKIA_PORT=${jolokiaPort.value}",
     bashScriptExtraDefines += s"JOLOKIA_HOST=${jolokiaHost.value}",
     bashScriptExtraDefines += s"JOLOKIA_PROTOCOL=${jolokiaProtocol.value}",
-    bashScriptExtraDefines += """addJava "-javaagent:${app_home}/../jolokia/jolokia.jar=port=${JOLOKIA_PORT},host=${JOLOKIA_HOST},protocol=${JOLOKIA_PROTOCOL}""""
+    bashScriptExtraDefines += s"JOLOKIA_POLICY_LOCATION=${jolokiaPolicyLocation.value}",
+    bashScriptExtraDefines += """addJava "-javaagent:${app_home}/../jolokia/jolokia.jar=port=${JOLOKIA_PORT},host=${JOLOKIA_HOST},protocol=${JOLOKIA_PROTOCOL},policyLocation=${JOLOKIA_POLICY_LOCATION}""""
   )
 
   private[this] val jolokiaFilter = configurationFilter("jolokia-jvm") && artifactFilter(`type` = "jar", classifier = "agent")


### PR DESCRIPTION
https://github.com/jtescher/sbt-jolokia/issues/8

This allows for setting the location of the Policy file used to restrict access to the Jolokia Agent:
https://jolokia.org/reference/html/security.html

I have set the default value of this setting to the same as what the docs have (`classpath:/jolokia-access.xml`), so this will not change the behavior of any users who do not want to explicitly set this flag.